### PR TITLE
Setup wallet, transactional, and test

### DIFF
--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -1,0 +1,2 @@
+class Credit < Transactional
+end

--- a/app/models/debit.rb
+++ b/app/models/debit.rb
@@ -1,0 +1,2 @@
+class Debit < Transactional
+end

--- a/app/models/transactional.rb
+++ b/app/models/transactional.rb
@@ -1,0 +1,41 @@
+class Transactional < ApplicationRecord
+  belongs_to :wallet
+  validate :check_balance
+
+  store_accessor :to, :note, :amount, :source
+
+  def check_balance
+    if self.type == 'Debit' && BigDecimal(Wallet.find_by_address(self.source).balance) < BigDecimal(self.amount)
+      errors.add(:amount, "of your wallet balance is not sufficient")
+    end
+  end
+
+  def to
+    self.details['to']
+  end
+
+  def note
+    self.details['note']
+  end
+
+  def source
+    self.details['source']
+  end
+
+  def amount
+    BigDecimal(self.details['amount'])
+  end
+
+  def self.total(wallet_id)
+    result = 0
+    total_transaction ||= where(wallet_id: wallet_id)
+    total_transaction.map do |transaction|
+      if transaction.type == 'Debit'
+        result += -transaction.amount
+      else
+        result += transaction.amount
+      end
+    end
+    result.to_f
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,14 @@
 class User < ApplicationRecord
+  has_one :wallet, dependent: :destroy
+  after_create :setup_wallet
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  
+  def setup_wallet
+    Wallet.create(address: SecureRandom.uuid, user_id: self.id, balance: 0)
+  end
 
   def self.only
     where(type: 'User')

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -1,0 +1,4 @@
+class Wallet < ApplicationRecord
+  belongs_to :user
+  has_many :transactionals
+end

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,0 +1,5 @@
+class ApplicationService
+  def self.call(*args, &block)
+    new(*args, &block).call
+  end
+end

--- a/app/services/wallet_transaction/base.rb
+++ b/app/services/wallet_transaction/base.rb
@@ -1,0 +1,9 @@
+module WalletTransaction
+  class Base < ApplicationService
+    attr_accessor :user_id, :details, :amount
+    
+    def initialize(params={})
+      @params       ||= params
+    end
+  end
+end

--- a/app/services/wallet_transaction/credit.rb
+++ b/app/services/wallet_transaction/credit.rb
@@ -1,0 +1,36 @@
+module WalletTransaction
+  class Credit < Base
+    def call
+      setup_params
+      credit
+    end
+
+    private
+
+    def setup_params
+      @details      ||= @params[:details]
+      @destination  ||= Wallet.find_by_address(@details[:to])
+      @destination_details ||= {
+        from: @details[:source],
+        to: @details[:to],
+        note: @details[:note],
+        amount: @details[:amount]
+      }
+    end
+
+    def credit
+      # sample usage:
+      # WalletTransaction::Credit.call(details: {source: 'topup', note: 'tes', to: user.wallet.address, amount: '1000'})
+      last_updated_at = @destination.updated_at
+
+      Transactional.transaction do
+        Transactional.create(type: 'Credit', date: DateTime.now, details: @destination_details, wallet_id: @destination.id)
+        @destination.update(balance: (BigDecimal(@destination.balance) + BigDecimal(@details[:amount])))
+      end
+
+      current_updated_at = @destination.reload.updated_at
+
+      return true if current_updated_at > last_updated_at
+    end
+  end
+end

--- a/app/services/wallet_transaction/debit.rb
+++ b/app/services/wallet_transaction/debit.rb
@@ -1,0 +1,46 @@
+module WalletTransaction
+  class Debit < Base
+    def call
+      setup_params
+      debit
+    end
+
+    private
+
+    def setup_params
+      @details      ||= @params[:details]
+      @source       ||= Wallet.find_by_address(@details[:source])
+      @sender       ||= @source.user
+      @amount       ||= @details[:amount]
+      @destination  ||= Wallet.find_by_address(@details[:to])
+      @destination_details ||= {
+        from: @source.id,
+        note: @details[:note],
+        amount: @details[:amount]
+      }
+      @receiver     ||= @destination.user
+    end
+
+    def debit
+      # sample usage:
+      # WalletTransaction::Debit.call(details: {source: user.wallet.address, note: 'transfer', to: team.wallet.address, amount: '10.75'})
+      source_last_updated_at    = @source.updated_at
+      transactional_last_length = Transactional.all.length
+
+      if BigDecimal(@source.balance) >= BigDecimal(@amount)
+        ActiveRecord::Base.transaction do
+          @source.update(balance: (@source.balance - BigDecimal(@amount)))
+          @destination.update!(balance: @destination.balance + BigDecimal(@amount))
+          Transactional.create(type: 'Debit', date: DateTime.now, details: @details, wallet_id: @source.id)
+          Transactional.create(type: 'Credit', date: DateTime.now, details: @destination_details, wallet_id: @destination.id)
+        end
+
+        source_current_updated_at = @source.reload.updated_at
+
+        return true if source_current_updated_at > source_last_updated_at
+      else
+        return false
+      end
+    end
+  end
+end

--- a/db/migrate/20220904020158_create_wallets.rb
+++ b/db/migrate/20220904020158_create_wallets.rb
@@ -1,0 +1,11 @@
+class CreateWallets < ActiveRecord::Migration[7.0]
+  def change
+    create_table :wallets do |t|
+      t.string :address
+      t.bigint :balance, default: 0
+      t.belongs_to :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220904043425_create_transactionals.rb
+++ b/db/migrate/20220904043425_create_transactionals.rb
@@ -1,0 +1,12 @@
+class CreateTransactionals < ActiveRecord::Migration[7.0]
+  def change
+    create_table :transactionals do |t|
+      t.datetime :date
+      t.json :details
+      t.string :type
+      t.belongs_to :wallet, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_03_142137) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_04_043425) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "transactionals", force: :cascade do |t|
+    t.datetime "date"
+    t.json "details"
+    t.string "type"
+    t.bigint "wallet_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["wallet_id"], name: "index_transactionals_on_wallet_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -27,4 +37,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_03_142137) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "wallets", force: :cascade do |t|
+    t.string "address"
+    t.bigint "balance", default: 0
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_wallets_on_user_id"
+  end
+
+  add_foreign_key "transactionals", "wallets"
+  add_foreign_key "wallets", "users"
 end

--- a/spec/factories/transactionals.rb
+++ b/spec/factories/transactionals.rb
@@ -1,0 +1,32 @@
+FactoryBot.define do
+  factory :transactional do
+    date { DateTime.now }
+    type { nil }
+    details { nil }
+    wallet_id { nil }
+
+    trait :debit_to_team do
+      type { 'Debit' }
+      details { {source: User.first.wallet.address, note: 'transfer', to: Team.first.wallet.address, amount: '10.75'} }
+      wallet_id { User.first.wallet.id }
+    end
+
+    trait :debit_to_user do
+      type { 'Debit' }
+      details { {source: Team.first.wallet.address, note: 'transfer', to: User.first.wallet.address, amount: '10.75'} }
+      wallet_id { Team.first.wallet.id }
+    end
+
+    trait :credit_to_user do
+      type { 'Credit' }
+      details { {source: 'topup', note: 'tes', to: User.first.wallet.address, amount: '1000'} }
+      wallet_id { User.first.wallet.id }
+    end
+
+    trait :credit_to_team do
+      type { 'Credit' }
+      details { {source: 'topup', note: 'tes', to: Team.first.wallet.address, amount: '1000'} }
+      wallet_id { Team.first.wallet.id }
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :user do
-    sequence(:email) { |n| "user-#{n}@dummy.com" }
+    sequence(:email) { |n| "user-#{DateTime.now.to_i}@dummy.com" }
     password { 'password' }
 
     trait :team do
-      sequence(:email) { |n| "team-#{n}@dummy.com" }
+      sequence(:email) { |n| "team-#{DateTime.now.to_i}@dummy.com" }
       type { 'Team' }
     end
   end

--- a/spec/factories/wallets.rb
+++ b/spec/factories/wallets.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :wallet do
+    address { SecureRandom.uuid }
+    user { nil }
+  end
+end

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe Transactional, type: :model do
+  context "not able create Transactional" do
+    before do
+      user = create(:user)
+      team = create(:user, :team)
+    end
+
+    it "when team has low balance" do
+      transactional = build(:transactional, :debit_to_user)
+
+      expect(transactional).to_not be_valid
+    end
+
+    it "when team has low balance" do
+      transactional = build(:transactional, :debit_to_team)
+
+      expect(transactional).to_not be_valid
+    end
+  end
+
+  context "able create Transactional" do
+    before do
+      @user = create(:user)
+      @team = create(:user, :team)
+      @transactional = create(:transactional, type: 'Credit', details: {source: 'topup', note: 'tes', to: @user.wallet.address, amount: '1000'}, wallet_id: @user.wallet.id)
+      @user.wallet.update(balance: '1000')
+    end
+
+    it "when team has enough balance" do
+      transactional = create(:transactional, type: 'Debit', details: {source: @user.wallet.address, note: 'transfer', to: @team.wallet.address, amount: '10.75'}, wallet_id: @user.wallet.id)
+
+      expect(transactional).to be_valid
+    end
+
+    it "when team has enough balance" do
+      transactional = build(:transactional, :debit_to_team)
+
+      expect(transactional).to be_valid
+    end
+  end
+
+  context "able read keys" do
+    before do
+      @user = create(:user)
+      @team = create(:user, :team)
+      @transactional = create(:transactional, type: 'Credit', details: {source: 'topup', note: 'tes', to: @user.wallet.address, amount: '1000'}, wallet_id: @user.wallet.id)
+      @user.wallet.update(balance: '1000')
+      create(:transactional, type: 'Debit', details: {source: @user.wallet.address, note: 'transfer', to: @team.wallet.address, amount: '10.75'}, wallet_id: @user.wallet.id)
+    end
+
+    it "able read 'to' attribute" do
+      expect(@transactional.to).not_to be_nil
+    end
+
+    it "able to read 'note' attribute " do
+      expect(@transactional.note).not_to be_nil
+    end
+
+    it "able to read 'total' attribute " do
+      expect(Transactional.total(@user.wallet.id)).not_to be_nil
+    end
+  end
+end

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Wallet, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/services/wallet_transaction_spec.rb
+++ b/spec/services/wallet_transaction_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe "Homes", type: :service_object do
+  before(:all) do
+    @user = create(:user)
+    @team = create(:user, :team)
+  end
+
+  describe "WalletTransaction::Credit.call" do
+    it "able to topup balance" do
+      expect(
+        WalletTransaction::Credit.call(
+          details: {
+            source: 'topup', note: 'tes', to: @user.wallet.address, amount: '1000'
+          }
+        )
+      ).to eq true
+    end
+  end
+
+  describe "WalletTransaction::Debit.call" do
+    it "able to debit balance, wallet balance enough" do
+      @transactional = create(:transactional, type: 'Credit', details: {source: 'topup', note: 'tes', to: @user.wallet.address, amount: '1000'}, wallet_id: @user.wallet.id)
+      @user.wallet.update(balance: '1000')
+
+      expect(
+        WalletTransaction::Debit.call(
+          details: {
+            source: @user.wallet.address, note: 'tes', to: @team.wallet.address, amount: '100'
+          }
+        )
+      ).to eq true
+    end
+
+    it "debit on low balance, wallet balance not change" do
+      expect do
+        WalletTransaction::Debit.call(
+          details: {
+            source: @user.wallet.address, note: 'tes', to: @team.wallet.address, amount: '100'
+          }
+        )
+      end.not_to change { @user.wallet.balance }
+    end
+
+    it "debit on low balance, wallet balance not change" do
+      expect(
+        WalletTransaction::Debit.call(
+          details: {
+            source: @user.wallet.address, note: 'tes', to: @team.wallet.address, amount: '100'
+          }
+        )
+      ).to eq false
+    end
+  end
+end


### PR DESCRIPTION
Create wallets and transactionals table and migrate

Setup models relationship and methods:
- add callback to create wallet for user with setup_wallet method
- add store_accessor to read `to`, `note`, `amount`, and `source` from
  details field with json type
- add `total` to sum all user wallet transaction

Create credit and debit models and inherit from transactional model

Setup WalletTransaction service object:
- handle debit and credit

Update test:
- setup factories for: users, wallets, and transactionals
- setup test for models: transaction and wallet
- setup test for WalletTransaction service object